### PR TITLE
The review-routing.component was messed up...

### DIFF
--- a/src/angular-app/languageforge/review-suggest/src/client/app/review/review-routing.module.ts
+++ b/src/angular-app/languageforge/review-suggest/src/client/app/review/review-routing.module.ts
@@ -5,7 +5,7 @@ import { ReviewComponent } from './review.component';
 @NgModule({
   imports: [
     RouterModule.forChild([
-      { path: 'definition', component: ReviewComponent }
+      { path: 'review', component: ReviewComponent }
     ])
   ],
   exports: [RouterModule]

--- a/src/angular-app/languageforge/review-suggest/src/client/app/shared/navbar/navbar.component.html
+++ b/src/angular-app/languageforge/review-suggest/src/client/app/shared/navbar/navbar.component.html
@@ -6,7 +6,7 @@
       <ul class="right hide-on-med-and-down">
         <li routerLinkActive="active"><a routerLink="/auth">Logon</a></li>
         <li routerLinkActive="active"><a routerLink="/dashboard">Dashboard</a></li>
-        <li routerLinkActive="active"><a routerLink="/definition">Review</a></li>
+        <li routerLinkActive="active"><a routerLink="/review">Review</a></li>
         <li routerLinkActive="active"><a routerLink="/test-services">Test Services</a></li>
         <li><a (click)="logout()">Logout</a></li>
       </ul>


### PR DESCRIPTION
...  in one of the merges and the application wasn't able to access the review page using the nav-bar.
This has been fixed by renaming the expected route from "definition" (this no longer exists in the application) to "review" .