### PR TITLE
Bugfix: reverting change to site logic

### DIFF
--- a/src/Api/Library/Shared/Website.php
+++ b/src/Api/Library/Shared/Website.php
@@ -90,11 +90,6 @@ class Website
             }
         }
 
-        $pos = strpos($_SERVER['HTTP_HOST'], 'm.');
-        if ($pos === 0) {
-            return substr($_SERVER['HTTP_HOST'], 2);
-        }
-
         return $_SERVER['HTTP_HOST'];
     }
 


### PR DESCRIPTION
When r-s is deployed on server (opposed to running on a separate server or locally) the twig template was loading from the wrong place. This is because of a change that I made (and am now reverting) to the logic that sets the site. One of the API calls (can't remember which) has logic that is based on hostname. We didn't end up using that API call so we can revert this change and fix the loading of the twig template.